### PR TITLE
Updating links on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ More to come :), Feedback encouraged.
 
 [Checkout our resources that are compatible with any language](https://github.com/saradiaz/appsec-toolbelt/tree/master/LanguageAgnostic)
 
-We're still working on it! [Checkout our TODO](https://github.com/saradiaz/appsec-toolbelt/blob/master/TODO)
+We're still working on it! [Checkout our TODO](https://github.com/saradiaz/appsec-toolbelt/blob/master/TODO.md)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ All tools are free and open source. (July 20th, 2017)
 
 More to come :), Feedback encouraged.  
 
-[Checkout our Security Baseline](security-baseline.md)
+[Checkout our Security Baseline](BestPractices/security-baseline.md)
 
 [Checkout our Java resources](Java)  
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ All tools are free and open source. (July 20th, 2017)
 
 More to come :), Feedback encouraged.  
 
-[Checkout our Security Baseline](https://github.com/saradiaz/appsec-toolbelt/tree/master/BestPractices/security-baseline.md)
+[Checkout our Security Baseline](security-baseline.md)
 
-[Checkout our Java resources](https://github.com/saradiaz/appsec-toolbelt/tree/master/Java)  
+[Checkout our Java resources](Java)  
 
-[Checkout our JS resources](https://github.com/saradiaz/appsec-toolbelt/tree/master/JavaScript)  
+[Checkout our JS resources](JavaScript)  
 
-[Checkout our Ruby resources](https://github.com/saradiaz/appsec-toolbelt/tree/master/Ruby)  
+[Checkout our Ruby resources](Ruby)  
 
-[Checkout our Python resources](https://github.com/saradiaz/appsec-toolbelt/tree/master/Python)  
+[Checkout our Python resources](Python)  
 
-[Checkout our resources that are compatible with any language](https://github.com/saradiaz/appsec-toolbelt/tree/master/LanguageAgnostic)
+[Checkout our resources that are compatible with any language](LanguageAgnostic)
 
-We're still working on it! [Checkout our TODO](https://github.com/saradiaz/appsec-toolbelt/blob/master/TODO.md)
+We're still working on it! [Checkout our TODO](TODO.md)
 


### PR DESCRIPTION
Hello, I have noticed that the link of the **Checkout our TODO** on the README is not working, I have fixed the link (it was just missing a .md). 

Also, I changed all the links on the Readme to be [relative links](https://github.com/blog/1395-relative-links-in-markup-files), with that if someone forks the project, the links on the forked project will be pointing to the documents on the forked project itself instead of pointing to the original project.