### PR TITLE
Update nsp.md

### DIFF
--- a/JavaScript/dependency-checking/nsp.md
+++ b/JavaScript/dependency-checking/nsp.md
@@ -2,7 +2,7 @@
 Node Security Project (nsp) checks the dependencies in your project's package.json against libraries of known vulnerabilities. If your project uses vulnerable versions of a dependency, it will let you know and provide helpful details.
 
 ### Installation
-`$ npm install --save-dev nsp`
+`$ npm install -g --save-dev nsp`
 
 ### Usage
 Running `$ nsp check` inside your project will generate a well formatted report in stdout

--- a/JavaScript/source-code-analysis/eslint.md
+++ b/JavaScript/source-code-analysis/eslint.md
@@ -3,10 +3,10 @@
 
 note: -D is --save-dev
 
-`$ npm install -D eslint`  
-`$ npm install -D eslint-plugin-security`  
-`$ npm install -D eslint-plugin-scanjs-rules`  
-`$ npm install -D eslint-plugin-no-unsafe-innerhtml`  
+`$ npm install -g -D eslint`  
+`$ npm install -g -D eslint-plugin-security`  
+`$ npm install -g -D eslint-plugin-scanjs-rules`  
+`$ npm install -g -D eslint-plugin-no-unsafe-innerhtml`  
 
 ### Once you've done this, you can either
 * use the .eslintrc.json as-is from this repo


### PR DESCRIPTION
-g for global. Without this flag the tool is installed inside of the repo that you want to scan, and nsp isn't in your $PATH